### PR TITLE
use Amazon python base for resolving security findings in SOC2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim AS sqitch-build
+FROM amazon/aws-lambda-python:3.9 AS sqitch-build
 
 # Install system dependencies.
 WORKDIR /work
@@ -31,7 +31,7 @@ RUN perl Build.PL --quiet --install_base /app --etcdir /etc/sqitch \
 
 ################################################################################
 # Copy to the final image without all the build stuff.
-FROM python:3.9-slim AS sqitch
+FROM amazon/aws-lambda-python:3.9 AS sqitch
 
 # Install runtime system dependencies and remove unnecesary files.
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \


### PR DESCRIPTION
AWS python base is security checked. We had a lot of security warnings in the docker image. 