### PR TITLE
Allow passing envvar into build process to build base image for a spe…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9-slim AS sqitch-build
+ARG PY_VERSION
+FROM python:${PY_VERSION}-slim AS sqitch-build
 
 # Install system dependencies.
 WORKDIR /work
@@ -31,7 +32,7 @@ RUN perl Build.PL --quiet --install_base /app --etcdir /etc/sqitch \
 
 ################################################################################
 # Copy to the final image without all the build stuff.
-FROM python:3.9-slim AS sqitch
+FROM python:${PY_VERSION}-slim AS sqitch
 
 # Install runtime system dependencies and remove unnecesary files.
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
@@ -56,7 +57,8 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && useradd -r -g sqitch --uid=1024 -d /home sqitch \
     && chown -R sqitch:sqitch /home
 
-RUN apt-get update && apt-get install -y python3-pip
+RUN apt-get update && apt-get install -y python3-pip curl git-lfs
+RUN pip install poetry==1.2.2
 
 # Copy the app and config from the build image.
 COPY --from=sqitch-build /app .

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Kolena
 Steps for building Kolena sqitch images:
 
 ```sh
-for py_version in 3.7 3.8 3.9 3.10
+for py_version in 3.7 3.8 3.9 3.10 3.11
 do
     env PY_VERSION=${py_version} ./build --build-arg sf_account=kolena-eng
     docker push ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0-py${py_version}

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Kolena
 Steps for building Kolena sqitch images:
 
 ```sh
-./build
-docker tag sqitch/sqitch:1.1.0 ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0
-docker push ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0
-env DIR=snowflake ./build --build-arg sf_account=ara65239
-docker tag sqitch/sqitch:1.1.0-snowflake ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0-snowflake
-docker push ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0-snowflake
+for py_version in 3.7 3.8 3.9 3.10
+do
+    env PY_VERSION=${py_version} ./build --build-arg sf_account=kolena-eng
+    docker push ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0-py${py_version}
+    env DIR=snowflake PY_VERSION=${py_version} ./build --build-arg sf_account=kolena-eng
+    docker push ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0-snowflake-py${py_version}
+done
 ```
 
 Synopsis

--- a/build
+++ b/build
@@ -45,7 +45,6 @@ docker buildx build --platform=linux/amd64 --pull \
   --label org.opencontainers.image.ref.name="sqitch${PKG}-${VERSION}" \
   --label org.opencontainers.image.title="Sqitch" \
   --label org.opencontainers.image.description="Sensible database change management" \
-  --platform linux/amd64 \
   "${tagopt[@]}" \
   --build-arg "VERSION=${VERSION}" \
   --build-arg "PY_VERSION=${PY_VERSION}" \

--- a/build
+++ b/build
@@ -6,7 +6,8 @@ NAME=sqitch
 VERSION=1.1.0
 
 DIR=${DIR:=.}
-REGISTRY=${REGISTRY:="$NAME"}
+PY_VERSION=${PY_VERSION:="3.9"}
+REGISTRY=${REGISTRY:="ghcr.io/kolenaio/docker-sqitch"}
 GIT_BRANCH=${GIT_BRANCH:-${TRAVIS_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}}
 
 # For main Sqitch build, the main tag is "latest" and there
@@ -28,7 +29,7 @@ if [[ "$GIT_BRANCH" =~ (^|/)main$ ]]; then
 fi
 
 # Always include the version tag.
-tagopt+=(--tag "${REGISTRY}/${NAME}:${VERSION}${PKG}")
+tagopt+=(--tag "${REGISTRY}/${NAME}:${VERSION}${PKG}-py${PY_VERSION}")
 
 docker build --pull \
   --label org.opencontainers.image.created=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
@@ -43,6 +44,8 @@ docker build --pull \
   --label org.opencontainers.image.ref.name="sqitch${PKG}-${VERSION}" \
   --label org.opencontainers.image.title="Sqitch" \
   --label org.opencontainers.image.description="Sane database change management" \
+  --platform linux/amd64 \
   "${tagopt[@]}" \
   --build-arg "VERSION=${VERSION}" \
+  --build-arg "PY_VERSION=${PY_VERSION}" \
   "$@" .

--- a/snowflake/Dockerfile
+++ b/snowflake/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.9-slim AS snow-build
+ARG VERSION
+ARG PY_VERSION
+FROM python:${PY_VERSION}-slim AS snow-build
 
 WORKDIR /work
 
@@ -36,7 +38,7 @@ RUN apt-get -qq update \
     && ./snowsql -Uv \
     && echo "[connections]\naccountname = $sf_account\n\n[options]\nnoup = true" > /var/snowsql/.snowsql/config
 
-FROM ghcr.io/kolenaio/docker-sqitch/sqitch:1.1.0
+FROM ghcr.io/kolenaio/docker-sqitch/sqitch:${VERSION}-py${PY_VERSION}
 
 # Install runtime dependencies, remove unnecesary files, and create log dir.
 USER root


### PR DESCRIPTION
…cific python version

Using this to provide CircleCI builds with the correct base sqitch image for varying python versions.